### PR TITLE
Support spider callbacks returning dict items

### DIFF
--- a/scrapy_deltafetch/middleware.py
+++ b/scrapy_deltafetch/middleware.py
@@ -76,7 +76,7 @@ class DeltaFetch(object):
                     if self.stats:
                         self.stats.inc_value('deltafetch/skipped', spider=spider)
                     continue
-            elif isinstance(r, BaseItem):
+            elif isinstance(r, (BaseItem, dict)):
                 key = self._get_key(response.request)
                 self.db[key] = str(time.time())
                 if self.stats:

--- a/tests/test_deltafetch.py
+++ b/tests/test_deltafetch.py
@@ -173,6 +173,22 @@ class DeltaFetchTestCase(TestCase):
                               b'test_key_2']))
         assert mw.db[b'key']
 
+    def test_process_spider_output_dict(self):
+        self._create_test_db()
+        mw = self.mwcls(self.temp_dir, reset=False, stats=self.stats)
+        mw.spider_opened(self.spider)
+        response = mock.Mock()
+        response.request = Request('http://url',
+                                   meta={'deltafetch_key': 'key'})
+        result = [{"somekey": "somevalue"}]
+        self.assertEqual(list(mw.process_spider_output(
+            response, result, self.spider)), result)
+        self.assertEqual(set(mw.db.keys()),
+                         set([b'key',
+                              b'test_key_1',
+                              b'test_key_2']))
+        assert mw.db[b'key']
+
     def test_process_spider_output_stats(self):
         self._create_test_db()
         mw = self.mwcls(self.temp_dir, reset=False, stats=self.stats)


### PR DESCRIPTION
Scrapy 1.0 supports returning dict in callbacks
http://doc.scrapy.org/en/latest/news.html#support-for-returning-dictionaries-in-spiders

See https://github.com/scrapy/scrapy/pull/1081