### PR TITLE
fix deltafetch_reset argument example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Supported Scrapy spider arguments
 
 Example::
 
-    $ scrapy crawl example -s deltafetch_reset=1
+    $ scrapy crawl example -a deltafetch_reset=1
 
 
 Supported Scrapy request meta keys


### PR DESCRIPTION
This PR fixes the command line example for resetting deltafetch database.

The current example provides `deltafetch_reset` as a setting, when it should be an argument.