### PR TITLE
Added <deltafetch_passthrough> request metaparameter.

### DIFF
--- a/scrapy_deltafetch/middleware.py
+++ b/scrapy_deltafetch/middleware.py
@@ -74,7 +74,7 @@ class DeltaFetch(object):
 
     def process_spider_output(self, response, result, spider):
         for r in result:
-            if isinstance(r, Request):
+            if isinstance(r, Request) and not r.meta.get('deltafetch_passthrough') == True:
                 key = self._get_key(r)
                 if self.db.has_key(key):
                     logger.info("Ignoring already visited: %s" % r)


### PR DESCRIPTION
This allows for more fine-tuned applicability of deltafetch.
Even if deltafetch wants to skip a request, setting this parameter will force it to go through.
Example:
scrapy.Request(url=myUrl, meta={'deltafetch_passthrough':True})