### PR TITLE
Update required Scrapy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires=['Scrapy>=1.0', 'bsddb3']
+    install_requires=['Scrapy>=1.1.0', 'bsddb3']
 )


### PR DESCRIPTION
scrapy-deltafetch uses import that's available only since Scrapy 1.1.0
https://github.com/scrapy-plugins/scrapy-deltafetch/blob/c409d60b4c732c95b9aa23653a5463baba7abdfd/scrapy_deltafetch/middleware.py#L9