### PR TITLE
add meta key named "request_need_deltafetch" .

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,3 +88,8 @@ Supported Scrapy request meta keys
   more efficient for sites that many URLs for the same item.
 
 
+* ``request_need_deltafetch`` — force current request to be stored by deltafetch
+
+Example::
+
+    yield scrapy.Request(detail_url, self.parse_level2_pages, meta={'request_need_deltafetch':True})

--- a/scrapy_deltafetch/middleware.py
+++ b/scrapy_deltafetch/middleware.py
@@ -81,6 +81,10 @@ class DeltaFetch(object):
                     if self.stats:
                         self.stats.inc_value('deltafetch/skipped', spider=spider)
                     continue
+                elif r.meta.get('request_need_deltafetch'):
+                    self.db[key] = str(time.time())
+                    if self.stats:
+                        self.stats.inc_value('deltafetch/force_stored', spider=spider)                    
             elif isinstance(r, (BaseItem, dict)):
                 key = self._get_key(response.request)
                 self.db[key] = str(time.time())


### PR DESCRIPTION
user could use this key to force deltafetch store current request footprint .

it is usable way to fix re-directing request issue .