### PR TITLE
replace BaseItem to Item (BaseItem deprecated in Scrapy 2.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+.idea

--- a/scrapy_deltafetch/middleware.py
+++ b/scrapy_deltafetch/middleware.py
@@ -3,7 +3,7 @@ import os
 import time
 
 from scrapy.http import Request
-from scrapy.item import BaseItem
+from scrapy.item import Item
 from scrapy.utils.request import request_fingerprint
 from scrapy.utils.project import data_path
 from scrapy.utils.python import to_bytes
@@ -81,7 +81,7 @@ class DeltaFetch(object):
                     if self.stats:
                         self.stats.inc_value('deltafetch/skipped', spider=spider)
                     continue
-            elif isinstance(r, (BaseItem, dict)):
+            elif isinstance(r, (Item, dict)):
                 key = self._get_key(response.request)
                 self.db[key] = str(time.time())
                 if self.stats:

--- a/tests/test_deltafetch.py
+++ b/tests/test_deltafetch.py
@@ -4,7 +4,7 @@ import os
 import mock
 import tempfile
 from scrapy import Request
-from scrapy.item import BaseItem
+from scrapy.item import Item
 from scrapy.spiders import Spider
 from scrapy.settings import Settings
 from scrapy.exceptions import NotConfigured
@@ -192,7 +192,7 @@ class DeltaFetchTestCase(TestCase):
                               b'test_key_2']))
 
         # if the spider returns items, the request's key is added in db
-        result = [BaseItem(), "not a base item"]
+        result = [Item(), "not a base item"]
         self.assertEqual(list(mw.process_spider_output(
             response, result, self.spider)), result)
         self.assertEqual(set(mw.db.keys()),
@@ -235,7 +235,7 @@ class DeltaFetchTestCase(TestCase):
         self.assertEqual(list(mw.process_spider_output(
             response, result, self.spider)), [result[0]])
         self.assertEqual(self.stats.get_value('deltafetch/skipped'), 1)
-        result = [BaseItem(), "not a base item"]
+        result = [Item(), "not a base item"]
         self.assertEqual(list(mw.process_spider_output(
             response, result, self.spider)), result)
         self.assertEqual(self.stats.get_value('deltafetch/stored'), 1)
@@ -305,7 +305,7 @@ class DeltaFetchTestCase(TestCase):
             response, result, self.spider)), [result[0]])
         self.assertEqual(self.stats.get_value('deltafetch/skipped'), None)
 
-        result = [BaseItem(), "not a base item"]
+        result = [Item(), "not a base item"]
         self.assertEqual(list(mw.process_spider_output(
             response, result, self.spider)), result)
         self.assertEqual(self.stats.get_value('deltafetch/stored'), None)


### PR DESCRIPTION
This is minor edit, just pure deprecation of BaseItem in favor of Item.