### PR TITLE
fix deprecated calls to `scrapy.utils.request.request_fingerprint`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
         sudo apt-get install libdb-dev
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip

--- a/scrapy_deltafetch/middleware.py
+++ b/scrapy_deltafetch/middleware.py
@@ -5,7 +5,7 @@ import dbm
 
 from scrapy.http import Request
 from scrapy.item import Item
-from scrapy.utils.request import request_fingerprint
+from scrapy.utils.request import fingerprint
 from scrapy.utils.project import data_path
 from scrapy.utils.python import to_bytes
 from scrapy.exceptions import NotConfigured
@@ -79,7 +79,7 @@ class DeltaFetch(object):
             yield r
 
     def _get_key(self, request):
-        key = request.meta.get('deltafetch_key') or request_fingerprint(request)
+        key = request.meta.get('deltafetch_key') or fingerprint(request)
         return to_bytes(key)
 
     def _is_enabled_for_request(self, request):

--- a/tests/test_deltafetch.py
+++ b/tests/test_deltafetch.py
@@ -9,7 +9,7 @@ from scrapy.item import Item
 from scrapy.spiders import Spider
 from scrapy.settings import Settings
 from scrapy.exceptions import NotConfigured
-from scrapy.utils.request import request_fingerprint
+from scrapy.utils.request import fingerprint
 from scrapy.utils.python import to_bytes
 from scrapy.statscollectors import StatsCollector
 from scrapy.utils.test import get_crawler
@@ -319,7 +319,7 @@ class DeltaFetchTestCase(TestCase):
         mw = self.mwcls(self.temp_dir, reset=True)
         test_req1 = Request('http://url1')
         self.assertEqual(mw._get_key(test_req1),
-                         to_bytes(request_fingerprint(test_req1)))
+                         to_bytes(fingerprint(test_req1)))
         test_req2 = Request('http://url2', meta={'deltafetch_key': b'dfkey1'})
         self.assertEqual(mw._get_key(test_req2), b'dfkey1')
 


### PR DESCRIPTION
Currently this plugin is broken on Scrapy 2.12

`scrapy.utils.request.request_fingerprint` was removed in Scrapy 2.12 (https://docs.scrapy.org/en/2.12/news.html#deprecation-removals)

If accepted, a version bump would be helpful :slightly_smiling_face: 