### PR TITLE
Resolve request_fingerprint deprecation removal in Scrapy 2.12.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,16 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        include:
+        - python-version: "3.9"
+        - python-version: "3.10"
+        - python-version: "3.11"
+        - python-version: "3.12"
+        - python-version: "3.13"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get install libdb-dev
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]

--- a/scrapy_deltafetch/middleware.py
+++ b/scrapy_deltafetch/middleware.py
@@ -30,7 +30,17 @@ class DeltaFetch(object):
         self.dir = dir
         self.reset = reset
         self.stats = stats
-        self.fingerprint=RequestFingerprinter(crawler).fingerprint
+        if crawler and hasattr(crawler, 'request_fingerprinter'):
+            self.fingerprint=crawler.request_fingerprinter.fingerprint
+        else:
+            try:
+                # compatibility with Scrapy <2.7.0
+                from scrapy.utils.request import request_fingerprint
+                self.fingerprint=request_fingerprint
+            except ImportError:
+                # use the new default 
+                from scrapy.utils.request import fingerprint
+                self.fingerprint=fingerprint
 
     @classmethod
     def from_crawler(cls, crawler):

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,12 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
-    install_requires=['Scrapy>=1.1.0']
+    install_requires=['Scrapy>=1.1.0'],
+    python_requires='>=3.9',
 )

--- a/tests/test_deltafetch.py
+++ b/tests/test_deltafetch.py
@@ -9,7 +9,7 @@ from scrapy.item import Item
 from scrapy.spiders import Spider
 from scrapy.settings import Settings
 from scrapy.exceptions import NotConfigured
-from scrapy.utils.request import request_fingerprint
+from scrapy.utils.request import RequestFingerprinter
 from scrapy.utils.python import to_bytes
 from scrapy.statscollectors import StatsCollector
 from scrapy.utils.test import get_crawler
@@ -318,8 +318,10 @@ class DeltaFetchTestCase(TestCase):
     def test_get_key(self):
         mw = self.mwcls(self.temp_dir, reset=True)
         test_req1 = Request('http://url1')
+        crawler = get_crawler(Spider)
+        fingerprint=RequestFingerprinter(crawler).fingerprint
         self.assertEqual(mw._get_key(test_req1),
-                         to_bytes(request_fingerprint(test_req1)))
+                         to_bytes(fingerprint(test_req1)))
         test_req2 = Request('http://url2', meta={'deltafetch_key': b'dfkey1'})
         self.assertEqual(mw._get_key(test_req2), b'dfkey1')
 

--- a/tests/test_deltafetch.py
+++ b/tests/test_deltafetch.py
@@ -9,10 +9,16 @@ from scrapy.item import Item
 from scrapy.spiders import Spider
 from scrapy.settings import Settings
 from scrapy.exceptions import NotConfigured
-from scrapy.utils.request import RequestFingerprinter
 from scrapy.utils.python import to_bytes
 from scrapy.statscollectors import StatsCollector
 from scrapy.utils.test import get_crawler
+
+try:
+    from scrapy.utils.request import request_fingerprint
+    _legacy_fingerprint=True
+except ImportError:
+    from scrapy.utils.request import RequestFingerprinter
+    _legacy_fingerprint=False
 
 from scrapy_deltafetch.middleware import DeltaFetch
 
@@ -319,7 +325,10 @@ class DeltaFetchTestCase(TestCase):
         mw = self.mwcls(self.temp_dir, reset=True)
         test_req1 = Request('http://url1')
         crawler = get_crawler(Spider)
-        fingerprint=RequestFingerprinter(crawler).fingerprint
+        if _legacy_fingerprint:
+            fingerprint=request_fingerprint
+        else:
+            fingerprint=RequestFingerprinter(crawler).fingerprint
         self.assertEqual(mw._get_key(test_req1),
                          to_bytes(fingerprint(test_req1)))
         test_req2 = Request('http://url2', meta={'deltafetch_key': b'dfkey1'})


### PR DESCRIPTION
Removal of ```scrapy.utils.request.request_fingerprint()```  breaks  ```scrapy_deltafetch```. I solved this by replacing the deprecated function with a ```RequestFingerprinter``` object according to the new specifications. Tests modified accordingly.

Thank you for a very useful package!

Closes https://github.com/scrapy-plugins/scrapy-deltafetch/pull/50.
